### PR TITLE
New type support: SecurityHotspot.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 dependencies {
     implementation("org.sonarsource.sonarqube:sonar-plugin-api:7.9")
 
-    compile("com.github.1c-syntax:bsl-language-server:7b97dbf040945cb25137a071ab58a347e3a75f76")
+    compile("com.github.1c-syntax:bsl-language-server:7b8b03ba436964717f7bd3b0177338868c0105c1")
     compile("com.fasterxml.jackson.core:jackson-databind:2.10.0")
     compile("com.google.code.findbugs:jsr305:3.0.2")
     // https://mvnrepository.com/artifact/org.sonarsource.analyzer-commons/sonar-analyzer-commons

--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
@@ -142,7 +142,7 @@ public class BSLCoreSensor implements Sensor {
       LOGGER.warn("Can't read content of file " + uri, e);
       content = "";
     }
-    DocumentContext documentContext = bslServerContext.addDocument(uri.toString(), content);
+    DocumentContext documentContext = bslServerContext.addDocument(uri, content);
 
     if (langServerEnabled) {
       diagnosticProvider.computeDiagnostics(documentContext)

--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/language/BSLLanguageServerRuleDefinition.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/language/BSLLanguageServerRuleDefinition.java
@@ -209,6 +209,7 @@ public class BSLLanguageServerRuleDefinition implements RulesDefinition {
     map.put(DiagnosticType.CODE_SMELL, RuleType.CODE_SMELL);
     map.put(DiagnosticType.ERROR, RuleType.BUG);
     map.put(DiagnosticType.VULNERABILITY, RuleType.VULNERABILITY);
+    map.put(DiagnosticType.SECURITY_HOTSPOT, RuleType.SECURITY_HOTSPOT);
 
     return map;
   }


### PR DESCRIPTION
New type support: SecurityHotspot. Changed addDocument parameter to raw uri.
https://github.com/1c-syntax/sonar-bsl-plugin-community/issues/65