### PR TITLE
При загрузке правил из внешних файлов больше не пропускается перывй файл

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/acc/ACCQualityProfile.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/acc/ACCQualityProfile.java
@@ -68,18 +68,27 @@ public class ACCQualityProfile implements BuiltInQualityProfilesDefinition {
       "ACC - full check",
       BSLLanguage.KEY
     );
+    activateDefaultRules(profile);
+    profile.done();
+  }
+
+  private void activateDefaultRules(NewBuiltInQualityProfile profile) {
+    ArrayList<String> activatedRules = new ArrayList<>();
     rulesFile.getRules()
       .stream()
       .filter(ACCRulesFile.ACCRule::isActive)
       .map(ACCRulesFile.ACCRule::getCode)
-      .forEach(key -> profile.activateRule(ACCRuleDefinition.REPOSITORY_KEY, key));
+      .forEach(key -> {
+        profile.activateRule(ACCRuleDefinition.REPOSITORY_KEY, key);
+        activatedRules.add(key);
+      });
     externalFiles.stream()
         .map(ACCRulesFile::getRules)
         .flatMap(Collection::stream)
         .filter(ACCRulesFile.ACCRule::isActive)
         .map(ACCRulesFile.ACCRule::getCode)
+        .filter(key -> !activatedRules.contains(key))
         .forEach(key -> profile.activateRule(ACCRuleDefinition.REPOSITORY_KEY, key));
-    profile.done();
   }
 
   private void addACC1CCertifiedProfile(Context context) {
@@ -87,16 +96,21 @@ public class ACCQualityProfile implements BuiltInQualityProfilesDefinition {
       "ACC - 1C:Compatible",
       BSLLanguage.KEY
     );
+    ArrayList<String> activatedRules = new ArrayList<>();
     rulesFile.getRules()
       .stream()
       .filter(ACCRulesFile.ACCRule::isNeedForCertificate)
       .map(ACCRulesFile.ACCRule::getCode)
-      .forEach(key -> profile.activateRule(ACCRuleDefinition.REPOSITORY_KEY, key));
+      .forEach(key -> {
+        profile.activateRule(ACCRuleDefinition.REPOSITORY_KEY, key);
+        activatedRules.add(key);
+      });;
     externalFiles.stream()
         .map(ACCRulesFile::getRules)
         .flatMap(Collection::stream)
         .filter(ACCRulesFile.ACCRule::isNeedForCertificate)
         .map(ACCRulesFile.ACCRule::getCode)
+        .filter(key -> !activatedRules.contains(key))
         .forEach(key -> profile.activateRule(ACCRuleDefinition.REPOSITORY_KEY, key));
     profile.done();
   }
@@ -106,17 +120,7 @@ public class ACCQualityProfile implements BuiltInQualityProfilesDefinition {
       "BSL - all rules",
       BSLLanguage.KEY
     );
-    rulesFile.getRules()
-      .stream()
-      .filter(ACCRulesFile.ACCRule::isActive)
-      .map(ACCRulesFile.ACCRule::getCode)
-      .forEach(key -> profile.activateRule(ACCRuleDefinition.REPOSITORY_KEY, key));
-    externalFiles.stream()
-        .map(ACCRulesFile::getRules)
-        .flatMap(Collection::stream)
-        .filter(ACCRulesFile.ACCRule::isActive)
-        .map(ACCRulesFile.ACCRule::getCode)
-        .forEach(key -> profile.activateRule(ACCRuleDefinition.REPOSITORY_KEY, key));
+    activateDefaultRules(profile);
     rulesBSL
       .forEach(key -> profile.activateRule(BSLLanguageServerRuleDefinition.REPOSITORY_KEY, key));
     profile.done();

--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/acc/ACCRulesFileReader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/acc/ACCRulesFileReader.java
@@ -39,23 +39,24 @@ public class ACCRulesFileReader {
   private static final Logger LOGGER = Loggers.get(ACCRulesFileReader.class);
 
   private final String[] filePaths;
-  private int current = 0;
+  private int current;
 
   public ACCRulesFileReader(String[] filePaths) {
-    this.filePaths = filePaths;
+    this.filePaths = filePaths.clone();
   }
 
   public Optional<ACCRulesFile> getNext() {
     if (hasMore()) {
+      Optional<ACCRulesFile> rules = getRulesFromFile();
       current++;
-      return getRulesFromFile();
+      return rules;
     }
 
     return Optional.empty();
   }
 
   public boolean hasMore() {
-    return current < filePaths.length - 1;
+    return current < filePaths.length;
   }
 
   public static Optional<ACCRulesFile> getRulesFromResource() {
@@ -63,7 +64,7 @@ public class ACCRulesFileReader {
 
     try {
       json = IOUtils.toString(
-          Objects.requireNonNull(ACCRuleDefinition.class.getClassLoader().getResourceAsStream("acc.json")),
+          Objects.requireNonNull(Thread.currentThread().getContextClassLoader().getResourceAsStream("acc.json")),
           StandardCharsets.UTF_8.name()
       );
     } catch (IOException e) {


### PR DESCRIPTION
Исправил ошибку в итераторе из-за которой пропускался первый файл при загрузке.
Это маскировало проблему с повторной попыткой активации правила. Добавил фильтрацию уже активированных правил.
