### PR TITLE
Удаление пробелов в строке с SourceDir

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
@@ -120,7 +120,7 @@ public class BSLCoreSensor implements Sensor {
 
     var absoluteSourceDirs = sourcesList.stream()
       .map((String sourceDir) -> {
-        Path sourcePath = Path.of(sourceDir);
+        Path sourcePath = Path.of(sourceDir.trim());
         if (sourcePath.isAbsolute()) {
           return sourcePath;
         } else {


### PR DESCRIPTION
Может падать при анализе dotnet:
```
java.nio.file.InvalidPathException: Illegal char <"> at index 0: "D:\a\OneScript.Web\OneScript.Web\src\OneScript\Application\ApplicationInstance.cs"
```

Пример: https://github.com/otymko/OneScript.Web/runs/1332790697?check_suite_focus=true