### PR TITLE
Make nightly build nightly again

### DIFF
--- a/.github/workflows/night_build.yml
+++ b/.github/workflows/night_build.yml
@@ -37,4 +37,4 @@ jobs:
           asset_path: ./build/libs/${{ env.PLUGIN_FILE_NAME }} # path to archive to upload
           asset_name: sonar-communitybsl-plugin-nightly-${{ env.PLUGIN_CURRENT_DATE }}.jar # name, format is "-nightly-20210101"
           asset_content_type: application/java-archive # required by GitHub API
-          # max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
+          max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted

--- a/.github/workflows/night_build.yml
+++ b/.github/workflows/night_build.yml
@@ -33,6 +33,6 @@ jobs:
           upload_url: https://uploads.github.com/repos/1c-syntax/sonar-bsl-plugin-community/releases/51033599/assets{?name,label} # find out this value by opening https://api.github.com/repos/<owner>/<repo>/releases in your browser and copy the full "upload_url" value including the {?name,label} part
           release_id: 51033599 # same as above (id can just be taken out the upload_url, it's used to find old releases)
           asset_path: ./build/libs/${{ env.PLUGIN_FILE_NAME }} # path to archive to upload
-          asset_name: sonar-communitybsl-plugin-$$.jar # name to upload the release as, use $$ to insert date (YYYYMMDD) and 6 letter commit hash
+          asset_name: sonar-communitybsl-plugin-nightly.jar # name to upload the release as, use $$ to insert date (YYYYMMDD) and 6 letter commit hash
           asset_content_type: application/java-archive # required by GitHub API
-          max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted
+          # max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted

--- a/.github/workflows/night_build.yml
+++ b/.github/workflows/night_build.yml
@@ -25,6 +25,8 @@ jobs:
         run: ./gradlew build
       - name: Save file name
         run: echo "PLUGIN_FILE_NAME=$(ls -t ./build/libs | head -1)" >> $GITHUB_ENV
+      - name: Save current date
+        run: echo "PLUGIN_CURRENT_DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
       - name: Deploy build
         uses: WebFreak001/deploy-nightly@v1.1.0
         env:
@@ -33,6 +35,6 @@ jobs:
           upload_url: https://uploads.github.com/repos/1c-syntax/sonar-bsl-plugin-community/releases/51033599/assets{?name,label} # find out this value by opening https://api.github.com/repos/<owner>/<repo>/releases in your browser and copy the full "upload_url" value including the {?name,label} part
           release_id: 51033599 # same as above (id can just be taken out the upload_url, it's used to find old releases)
           asset_path: ./build/libs/${{ env.PLUGIN_FILE_NAME }} # path to archive to upload
-          asset_name: sonar-communitybsl-plugin-nightly.jar # name to upload the release as, use $$ to insert date (YYYYMMDD) and 6 letter commit hash
+          asset_name: sonar-communitybsl-plugin-nightly-${{ env.PLUGIN_CURRENT_DATE }}.jar # name, format is "-nightly-20210101"
           asset_content_type: application/java-archive # required by GitHub API
           # max_releases: 7 # optional, if there are more releases than this matching the asset_name, the oldest ones are going to be deleted


### PR DESCRIPTION
Как сейчас:

1. Используется плейсхолдер для имени файла ночной сборки от экшена  WebFreak001/deploy-nightly
2. При резолве плейсхолдера получается текущая дата и хеш текущего коммита ветки плагина
3. Проверяется существование ассета в релизе с таким же хешом как и у текущего, если совпадают идёт отлуп от деплоя:
![image](https://user-images.githubusercontent.com/32082417/142297023-80f87eb3-46bf-464c-8ad8-f1ab82d82f8d.png)

Итого: Ночник деплоится только в случае наличия изменения в самом плагине, если изменения были только в зависимостях (BslLS) то этот ночник опубликован не будет

Что изменил:
1. Убрал использование плейсхолдера экшона

Итого: Согласно: https://github.com/WebFreak001/deploy-nightly/blob/master/index.js#L64 существующий ассет всегда будет перезаписываться  новый каждую сборку, соответственно мы получим все актуальные изменения BSLLS

Из минусов можно ответить что в имени ассета более не будет присутствовать дата\хеш и в текущей версии экшона по человечески не сделать, если мы указываем дату прям тут и тогда экшон перестанет вообще удалять устаревшие ассеты, т.к будет считать что они все с уникальными именами, если же мы оставляем плейсхолдер то пропускаем изменения BSLLS т.к хеш коммита плагина остаётся неизменным