### PR TITLE
Do not expose the plugin as SonarLint compatible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,7 +132,7 @@ tasks.jar {
         attributes["Plugin-SourcesUrl"] = "https://github.com/1c-syntax/sonar-bsl-plugin-community"
         attributes["Plugin-Developers"] = "Alexey Sosnoviy, Nikita Fedkin"
 
-        attributes["SonarLint-Supported"] = true
+        attributes["SonarLint-Supported"] = false
         attributes["Sonar-Version"] = sonarQubeVersion
 
         attributes["Plugin-Organization"] = "1c-syntax"


### PR DESCRIPTION
SonarLint is designed to only run SonarSource analyzers, not third party SonarQube Sensors. SonarLint is also much more restrictive regarding classloader (because we run inside IDEs).
See for example this issue:
https://community.sonarsource.com/t/error-in-sonarlint-for-rider/58490