### PR TITLE
feat: поддержка параметров-списков диагностик (тип List)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
@@ -386,8 +386,8 @@ public class BSLCoreSensor implements Sensor {
     } else if (type == Float.class) {
       value = Float.parseFloat(valueToCast);
     } else if (type == String.class || type == List.class) {
-      // List — параметр-список. Из SonarQube значение приходит строкой (через запятую);
-      // в List<String> оно разбирается уже на стороне BSL Language Server.
+      // Параметр-список: из SonarQube значение приходит одной строкой (элементы через запятую),
+      // а в список элементов оно разбирается уже на стороне BSL Language Server.
       value = valueToCast;
     } else {
       throw new IllegalArgumentException("Unsupported diagnostic parameter type " + type);

--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
@@ -385,9 +385,9 @@ public class BSLCoreSensor implements Sensor {
       value = Boolean.parseBoolean(valueToCast);
     } else if (type == Float.class) {
       value = Float.parseFloat(valueToCast);
-    } else if (type == String.class || type == Either.class) {
-      // Either<String, List<String>> — параметр-список. Из SonarQube значение приходит строкой
-      // (через запятую); в Either<String, ...> оно оборачивается уже на стороне BSL Language Server.
+    } else if (type == String.class || type == List.class) {
+      // List — параметр-список. Из SonarQube значение приходит строкой (через запятую);
+      // в List<String> оно разбирается уже на стороне BSL Language Server.
       value = valueToCast;
     } else {
       throw new IllegalArgumentException("Unsupported diagnostic parameter type " + type);

--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
@@ -385,7 +385,9 @@ public class BSLCoreSensor implements Sensor {
       value = Boolean.parseBoolean(valueToCast);
     } else if (type == Float.class) {
       value = Float.parseFloat(valueToCast);
-    } else if (type == String.class) {
+    } else if (type == String.class || type == Either.class) {
+      // Either<String, List<String>> — параметр-список. Из SonarQube значение приходит строкой
+      // (через запятую); в Either<String, ...> оно оборачивается уже на стороне BSL Language Server.
       value = valueToCast;
     } else {
       throw new IllegalArgumentException("Unsupported diagnostic parameter type " + type);

--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/language/BSLLanguageServerRuleDefinition.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/language/BSLLanguageServerRuleDefinition.java
@@ -194,8 +194,8 @@ public class BSLLanguageServerRuleDefinition implements RulesDefinition {
     if (type == Integer.class) {
       ruleParamType = RuleParamType.INTEGER;
     } else if (type == String.class || type == List.class) {
-      // List — параметр-список. В SonarQube UI не поддерживаются параметры правил в виде
-      // массива, поэтому остаётся строкой (значения через запятую).
+      // Параметр-список: массивы в параметрах правил SonarQube UI не поддерживаются,
+      // поэтому параметр остаётся строкой (элементы через запятую).
       ruleParamType = RuleParamType.STRING;
     } else if (type == Boolean.class) {
       ruleParamType = RuleParamType.BOOLEAN;

--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/language/BSLLanguageServerRuleDefinition.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/language/BSLLanguageServerRuleDefinition.java
@@ -40,6 +40,7 @@ import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.ext.heading.anchor.HeadingAnchorExtension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RuleParamType;
@@ -193,7 +194,9 @@ public class BSLLanguageServerRuleDefinition implements RulesDefinition {
 
     if (type == Integer.class) {
       ruleParamType = RuleParamType.INTEGER;
-    } else if (type == String.class) {
+    } else if (type == String.class || type == Either.class) {
+      // Either<String, List<String>> — параметр-список. В SonarQube UI не поддерживаются
+      // параметры правил в виде массива, поэтому остаётся строкой (значения через запятую).
       ruleParamType = RuleParamType.STRING;
     } else if (type == Boolean.class) {
       ruleParamType = RuleParamType.BOOLEAN;

--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/language/BSLLanguageServerRuleDefinition.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/language/BSLLanguageServerRuleDefinition.java
@@ -40,7 +40,6 @@ import org.commonmark.ext.gfm.tables.TablesExtension;
 import org.commonmark.ext.heading.anchor.HeadingAnchorExtension;
 import org.commonmark.parser.Parser;
 import org.commonmark.renderer.html.HtmlRenderer;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.server.rule.RuleParamType;
@@ -194,9 +193,9 @@ public class BSLLanguageServerRuleDefinition implements RulesDefinition {
 
     if (type == Integer.class) {
       ruleParamType = RuleParamType.INTEGER;
-    } else if (type == String.class || type == Either.class) {
-      // Either<String, List<String>> — параметр-список. В SonarQube UI не поддерживаются
-      // параметры правил в виде массива, поэтому остаётся строкой (значения через запятую).
+    } else if (type == String.class || type == List.class) {
+      // List — параметр-список. В SonarQube UI не поддерживаются параметры правил в виде
+      // массива, поэтому остаётся строкой (значения через запятую).
       ruleParamType = RuleParamType.STRING;
     } else if (type == Boolean.class) {
       ruleParamType = RuleParamType.BOOLEAN;


### PR DESCRIPTION
## Описание

Диагностики BSL Language Server получили тип параметра-списка **`List`** (значения через запятую либо массив). Плагин учит про этот тип:

- `BSLLanguageServerRuleDefinition.getRuleParamType`: `List.class → RuleParamType.STRING`. SonarQube UI не поддерживает параметры правил в виде массива, поэтому такой параметр остаётся строкой (значения через запятую).
- `BSLCoreSensor.castDiagnosticParameterValue`: для `List.class` значение прокидывается строкой как есть — в `List<String>` оно разбирается уже на стороне BSL Language Server.

Без этой правки параметр с типом `List` не смог бы пробрасываться: `getRuleParamType` вернул бы `null`, и параметр был бы исключён из описания правила.

## Зависимости

Тип `List` у параметров появляется в BSL Language Server — 1c-syntax/bsl-language-server#4268. Эта правка безопасна к отдельному мержу: новый код задействуется, когда потребляемая версия BSL LS начнёт отдавать параметры с типом `List`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W86iNs3Sj9wTS6NFFHvVbv)_