### PR TITLE
refactor: обработка файлов через workspace-пул BSL LS + бамп до 1.0.4.57-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ val commonmarkVersion = "0.27.1"
 dependencies {
     compileOnly("org.sonarsource.api.plugin", "sonar-plugin-api", "11.3.0.2824")
 
-    implementation("io.github.1c-syntax", "bsl-language-server", "1.0.5") {
+    implementation("io.github.1c-syntax", "bsl-language-server", "1.0.4.57-SNAPSHOT") {
         exclude("com.contrastsecurity", "java-sarif")
         exclude("info.picocli", "picocli-spring-boot-starter")
         exclude("me.tongfei", "progressbar")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,12 @@ tasks.withType<JavaCompile> {
 tasks.test {
     useJUnitPlatform()
 
+    // The tests boot the embedded BSL Language Server Spring context and run the sensor
+    // pipeline. Without an explicit heap the test JVM inherits the runner's default
+    // (a fraction of physical RAM), which is small on the macOS runners and led to
+    // OutOfMemoryError there. Pin a fixed heap so the pipeline has room on every runner.
+    maxHeapSize = "3g"
+
     testLogging {
         events("passed", "skipped", "failed")
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensor.java
@@ -60,6 +60,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -162,16 +164,22 @@ public class BSLCoreSensor implements Sensor {
         int total = inputFilesList.size();
         var count = new AtomicInteger(0);
 
-        inputFilesList.parallelStream().forEach((InputFile inputFile) -> {
-          var uri = inputFile.uri();
-          LOGGER.debug(uri.toString());
-          WorkspaceContextHolder.run(bslServerContext.getWorkspaceUri(),
-            () -> processFile(inputFile, bslServerContext));
-          var current = count.incrementAndGet();
-          if (current % COUNT_FILES_PB == 0) {
-            LOGGER.info("Processing files: {}/{}", current, total);
-          }
-        });
+        // Run the per-file work through BSL LS's workspace-scoped ForkJoinPool (cliExecutor):
+        // its worker threads are workspace-aware, so the workspace context is propagated
+        // automatically (same as the language server's own analyze command) and there is no need
+        // to wrap each file in WorkspaceContextHolder.run. A parallel stream launched from inside
+        // that pool's task executes on the pool's workspace-aware threads.
+        var executor = BSLLSBinding.getApplicationContext().getBean("cliExecutor", ExecutorService.class);
+        awaitInWorkspacePool(executor, sourceDir, () ->
+          inputFilesList.parallelStream().forEach((InputFile inputFile) -> {
+            LOGGER.debug(inputFile.uri().toString());
+            processFile(inputFile, bslServerContext);
+            var current = count.incrementAndGet();
+            if (current % COUNT_FILES_PB == 0) {
+              LOGGER.info("Processing files: {}/{}", current, total);
+            }
+          })
+        );
 
         LOGGER.info("Processing files: {}/{}", count.get(), total);
 
@@ -180,6 +188,25 @@ public class BSLCoreSensor implements Sensor {
     });
 
     BSLLSBinding.getApplicationContext().close();
+  }
+
+  /**
+   * Submit the per-source-directory work to BSL LS's workspace-scoped pool and wait for it to
+   * finish, translating the pool's checked failures into an unchecked {@link IllegalStateException}.
+   *
+   * @param executor  workspace-scoped executor (BSL LS {@code cliExecutor})
+   * @param sourceDir source directory being processed, used in the failure message
+   * @param work      per-source-directory processing to run on the pool's workspace-aware threads
+   */
+  static void awaitInWorkspacePool(ExecutorService executor, Path sourceDir, Runnable work) {
+    try {
+      executor.submit(work).get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while processing files in " + sourceDir, e);
+    } catch (ExecutionException e) {
+      throw new IllegalStateException("Error processing files in " + sourceDir, e);
+    }
   }
 
   private void processFile(InputFile inputFile, ServerContext bslServerContext) {

--- a/src/test/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensorPoolTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/sonar/BSLCoreSensorPoolTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is a part of SonarQube 1C (BSL) Community Plugin.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * SonarQube 1C (BSL) Community Plugin is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * SonarQube 1C (BSL) Community Plugin is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with SonarQube 1C (BSL) Community Plugin.
+ */
+package com.github._1c_syntax.bsl.sonar;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BSLCoreSensorPoolTest {
+
+  @Test
+  void wrapsExecutionExceptionAsIllegalState() throws Exception {
+    var executor = mock(ExecutorService.class);
+    Future<?> future = mock(Future.class);
+    doReturn(future).when(executor).submit(any(Runnable.class));
+    when(future.get()).thenThrow(new ExecutionException(new RuntimeException("boom")));
+
+    var sourceDir = Path.of("sourceDir");
+    assertThatThrownBy(() ->
+      BSLCoreSensor.awaitInWorkspacePool(executor, sourceDir, () -> { }))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("Error processing files in")
+      .hasMessageContaining("sourceDir");
+  }
+
+  @Test
+  void wrapsInterruptedExceptionAndRestoresInterruptFlag() throws Exception {
+    var executor = mock(ExecutorService.class);
+    Future<?> future = mock(Future.class);
+    doReturn(future).when(executor).submit(any(Runnable.class));
+    when(future.get()).thenThrow(new InterruptedException("interrupted"));
+
+    var sourceDir = Path.of("sourceDir");
+    assertThatThrownBy(() ->
+      BSLCoreSensor.awaitInWorkspacePool(executor, sourceDir, () -> { }))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("Interrupted while processing files in");
+
+    // The catch block restores the thread's interrupt status; consume it via
+    // Thread.interrupted() so the flag does not leak into other tests on this thread.
+    assertThat(Thread.interrupted()).isTrue();
+  }
+}


### PR DESCRIPTION
Адаптация плагина под BSL LS с исправлениями OOM и класслоадера. Корневые причины (родом из #445) поправлены в самом BSL LS, поэтому в плагине не осталось воркэраундов.

## Что делает PR

**1. Обработка файлов через workspace-scoped `cliExecutor` BSL LS** — вместо сырого `parallelStream` с ручным пробросом `WorkspaceContextHolder` по каждому файлу.
Воркеры его `ForkJoinPool` workspace-aware (устанавливают воркспейс в `onStart`), поэтому контекст воркспейса пробрасывается сам — ровно так, как это делает команда `analyze` самого языкового сервера. Submit/await вынесен в package-private `awaitInWorkspacePool` и покрыт тестами на пути `InterruptedException`/`ExecutionException`.

**2. Бамп `bsl-language-server` → `1.0.4.57-SNAPSHOT`.**
Снапшот содержит два постоянных фикса, снимающих необходимость в плагинных обходах:
- **`@Lazy(false)` на `EventPublisherAspectRegistration`** (1c-syntax/bsl-language-server#4294) — под глобальным lazy-init бин-регистратор всё равно поднимается, события жизненного цикла документов доходят, `AbstractDocumentLifecycleClearableIndex` (в т.ч. `InferredExpressionTypeIndex`) эвиктятся по-документно → скан больше не утекает в `OutOfMemoryError`.
- **Пин TCCL в `BSLLSBinding.createContext`** (1c-syntax/bsl-language-server#4296) — при старте контекста micrometer `ContextRegistry` в статической инициализации ищет `ThreadLocalAccessor` через `ServiceLoader.load(Class)` по thread context classloader. Под изолирующим класслоадером сканера SonarQube он не видел классы библиотеки → `NoClassDefFoundError: io.micrometer.context.ThreadLocalAccessor` и падение старта контекста (каскадом через `contextPropagatingDecorator → sentryExecutor → sentryAspect`). Теперь BSL LS сам пинит свой класслоадер на время старта.

**3. Явная тест-куча (`maxHeapSize = "3g"`).**
`BSLCoreSensorTest` многократно поднимает встроенный Spring-контекст BSL LS и гоняет весь конвейер сенсора; при активной шине событий футпринт подъёма превышает дефолтную тест-кучу раннеров и падает в OOM. Фиксируем кучу.

## Почему в плагине нет воркэраундов
Ранние итерации держали в плагине временный фильтр ленивости (`LazyInitializationExcludeFilter`) и обёртку TCCL вокруг сенсора. Оба обхода перенесены в BSL LS — правильный слой: библиотека владеет своим Spring-бутстрапом и знает собственный класслоадер, а выигрывают все встраивающие, не только этот плагин. Проверено интеграционным тестом (скан `ssl_3_1`/БСП через реальный сканер SonarQube) уже без обёрток.

## Коммиты
- `test: give the sensor tests an explicit heap` — тест-куча.
- `refactor: run file processing on BSL LS's workspace pool; require 1.0.4.57-SNAPSHOT` — executor + бамп зависимости.

## Перед мержем
Плагин пока прибит к снапшоту. Когда выйдет релиз BSL LS с #4294 + #4296 — заменить `1.0.4.57-SNAPSHOT` на релизную версию.

🤖 Generated with [Claude Code](https://claude.com/claude-code)